### PR TITLE
Add place user level booking limits

### DIFF
--- a/routes/place/constant/index.js
+++ b/routes/place/constant/index.js
@@ -1,20 +1,6 @@
-exports.TIME_FRAMES = Object.freeze({
-  breakfast: {
-    start: 6,
-    end: 11,
-  },
-  lunch: {
-    start: 11,
-    end: 17,
-  },
-  aperitif: {
-    start: 10,
-    end: 19,
-  },
-  dinner: {
-    start: 18,
-    end: 24,
-  },
+exports.BOOKING_LIMIT_PERIODS = Object.freeze({
+  week: 'week',
+  month: 'month',
 });
 
 exports.ACCESS = Object.freeze({

--- a/routes/place/index.js
+++ b/routes/place/index.js
@@ -8,8 +8,9 @@ const imageUplader = require('../../lib/imageUplader');
 const entityHelper = require('../../lib/entityHelper');
 const newPostPlaceSchema = require('./schema/postPlace');
 const newEditPlaceSchema = require('./schema/editPlace');
-const { TIME_FRAMES, ACCESS } = require('./constant');
+const { ACCESS } = require('./constant');
 const { GENDERS } = require('./../user/constant');
+const { BOOKING_LIMIT_PERIODS } = require('./constant');
 
 let User, Place, Offer, Counter, Booking, OfferPost, Interval, SamplePost;
 db.getInstance(function (p_db) {
@@ -79,7 +80,7 @@ module.exports = (app, placeRepository, placeTypeRepository, placeExtraRepositor
         type: 'Point',
         coordinates: [parseFloat(req.body.coordinates[0]), parseFloat(req.body.coordinates[1])],
       },
-      socials: req.body.socials ? 
+      socials: req.body.socials ?
         {
           facebook: req.body.socials.facebook || '',
           tripAdvisor: req.body.socials.tripAdvisor || '',
@@ -107,6 +108,8 @@ module.exports = (app, placeRepository, placeTypeRepository, placeExtraRepositor
       access: ACCESS.basic,
       allows: Object.values(GENDERS),
       timeFrames: req.body.timeFrames || {},
+      bookingLimits: req.body.bookingLimits || {},
+      bookingLimitsPeriod: req.body.bookingLimitsPeriod || BOOKING_LIMIT_PERIODS.week,
     };
 
     const seq = await Counter.findOneAndUpdate(
@@ -195,6 +198,8 @@ module.exports = (app, placeRepository, placeTypeRepository, placeExtraRepositor
             }
             place.timeFrames = newPlace.timeFrames;
           }
+          if (newPlace.bookingLimits) place.bookingLimits = newPlace.bookingLimits;
+          if (newPlace.bookingLimitsPeriod) place.bookingLimitsPeriod = newPlace.bookingLimitsPeriod;
 
           Place.replaceOne({_id: id }, place, function () {
             res.json({ message: "Place updated" });

--- a/routes/place/schema/editPlace/index.js
+++ b/routes/place/schema/editPlace/index.js
@@ -1,6 +1,8 @@
 const Joi = require('@hapi/joi');
+
 const { ACCESS } = require('./../../constant');
 const { GENDERS } = require('./../../../user/constant');
+const { BOOKING_LIMIT_PERIODS } = require('./../../constant');
 
 const daySchedule = Joi.string().strict();
 const dayTimeFrame = Joi.array().items(Joi.string());
@@ -49,6 +51,8 @@ const newSchema = (validTypes, validExtras) => Joi.object().keys({
     saturday: dayTimeFrame,
     sunday: dayTimeFrame,
   }),
+  bookingLimits: Joi.object().pattern(/^\d+$/, Joi.number().integer().strict()),
+  bookingLimitsPeriod: Joi.string().strict().valid(Object.values(BOOKING_LIMIT_PERIODS)),
 });
 
 module.exports = newSchema;

--- a/routes/place/schema/postPlace/index.js
+++ b/routes/place/schema/postPlace/index.js
@@ -1,5 +1,7 @@
 const Joi = require('@hapi/joi');
 
+const { BOOKING_LIMIT_PERIODS } = require('./../../constant');
+
 const daySchedule = Joi.string().strict();
 const dayTimeFrame = Joi.array().items(Joi.string());
 
@@ -41,6 +43,8 @@ const newSchema = (validTypes, validExtras) => Joi.object().keys({
     saturday: dayTimeFrame,
     sunday: dayTimeFrame,
   }),
+  bookingLimits: Joi.object().pattern(/^\d+$/, Joi.number().integer().strict()),
+  bookingLimitsPeriod: Joi.string().strict().valid(Object.values(BOOKING_LIMIT_PERIODS)),
 });
 
 module.exports = newSchema;


### PR DESCRIPTION
Venues can now specify how many times a week / month users of specific levels can make bookings. For that purpose, place now accepts two new fields for both POST and PUT requests. The fields are:
```
bookingLimits - object with keys representing levels, and values representing amount of possible bookings

e.g.
{
"1": 3,
"4": 5
}
```

```
bookingLimitsPeriod - string, valid values are 'week' and 'month', specifies whether bookingLimits should apply to week or month period
```

Examples:
```
bookingLimits: { "1": 3, "5": 5 }, bookingLimitsPeriod: "week"
```
This will result in users level 1, 2, 3, 4 being able to do 3 bookings per week at that venue, and users level 5 will be able to do 5 bookings.

```
bookingLimits: { "5": 5 }, bookingLimitsPeriod: "month"
```
This will result in users accross all levels to do 5 bookings per month at that venue.

```
bookingLimits: { "2": 3, "5": 5 }, bookingLimitsPeriod: "week"
```
This will result in users level 1, 2, 3, 4 to be able to do 3 bookings per week at that venue, and users level 5 to do 5 bookings.